### PR TITLE
条件部ありのトーク定義でシンタックスがおかしくなるのを修正しました

### DIFF
--- a/vscode-extension/syntaxes/aosora.tmLanguage.json
+++ b/vscode-extension/syntaxes/aosora.tmLanguage.json
@@ -11,12 +11,45 @@
 	],
 	"repository": {
 		"talkblock":{
-			"begin": "\\b(talk)\\s+((\\w|,)*)\\s*\\{",
-			"end": "\\}",
+			"begin": "\\b(talk)\\s+(\\w+)",
+			"end": "(?<=})",
 			"beginCaptures": {
 				"1": {"patterns": [{"include": "#keywords"}]},
 				"2": {"patterns": [{"include": "#symbols"}]}
 			},
+			"patterns": [
+				{
+					"include": "#talkif"
+				},
+				{
+					"include": "#talkbrace"
+				}
+			]
+		},
+		"talkif":{
+			"begin": "\\b(if)\\b",
+			"end": "(?<=\\))",
+			"beginCaptures": {
+				"1": {"patterns": [{"include": "#keywords"}]}
+			},
+			"patterns": [
+				{
+					"include": "#talkifbrace"
+				}
+			]
+		},
+		"talkifbrace":{
+			"begin": "\\(",
+			"end": "\\)",
+			"patterns": [
+				{
+					"include": "#rootblock"
+				}
+			]
+		},
+		"talkbrace": {
+			"begin": "\\{",
+			"end": "\\}",
 			"patterns": [
 				{
 					"match": "^\\s*(\\>)\\s*([^:]*)\\s*:?(.*)$",


### PR DESCRIPTION
```
talk hoge if (cond) {
    ...
}
```
のハイライトがおかしくなっていたのを修正しました。
もっとクレバーな方法があると思うので煮るなり焼くなりしてください。