### PR TITLE
関数式の糖衣構文を用意した

### DIFF
--- a/aosora-shiori/AST/ASTParser.h
+++ b/aosora-shiori/AST/ASTParser.h
@@ -52,7 +52,7 @@ namespace sakura {
 		static ASTNodeRef ParseASTWhile(ASTParseContext& parseContext);
 		static ASTNodeRef ParseASTFor(ASTParseContext& parseContext);
 		static ASTNodeRef ParseASTIf(ASTParseContext& parseContext);
-		static ASTNodeRef ParseASTReturn(ASTParseContext& parseContext);
+		static ASTNodeRef ParseASTReturn(ASTParseContext& parseContext, bool isLambdaSyntaxSugar = false);
 		static ASTNodeRef ParseASTBreak(ASTParseContext& parseContext);
 		static ASTNodeRef ParseASTContinue(ASTParseContext& parseContext);
 

--- a/aosora-shiori/Tokens/TokenParser.cpp
+++ b/aosora-shiori/Tokens/TokenParser.cpp
@@ -44,6 +44,7 @@ namespace sakura {
 	const std::string TOKEN_COMMON_COLON = ":";
 	const std::string TOKEN_COMMON_BRACKET_BEGIN = "(";
 	const std::string TOKEN_COMMON_BRACKET_END = ")";
+	const std::string TOKEN_COMMON_VERTICAL_BAR = "|";
 
 	const std::string TOKEN_KEYWORD_TALK = "talk";
 	const std::string TOKEN_KEYWORD_WORD = "word";
@@ -151,6 +152,7 @@ namespace sakura {
 		{TOKEN_COMMON_COLON, ScriptTokenType::Colon},
 		{TOKEN_COMMON_BRACKET_BEGIN, ScriptTokenType::BracketBegin},
 		{TOKEN_COMMON_BRACKET_END, ScriptTokenType::BracketEnd},
+		{TOKEN_COMMON_VERTICAL_BAR, ScriptTokenType::VerticalBar},
 
 		{TOKEN_BLOCK_BEGIN, ScriptTokenType::BlockBegin},
 		{TOKEN_BLOCK_END, ScriptTokenType::BlockEnd},

--- a/aosora-shiori/Tokens/TokenParser.h
+++ b/aosora-shiori/Tokens/TokenParser.h
@@ -46,6 +46,7 @@ namespace sakura {
 		Colon,
 		BracketBegin,
 		BracketEnd,
+		VerticalBar,
 		Talk,
 		Word,
 		Function,


### PR DESCRIPTION
```
local f = function(a, b) {
    local c = a + b;
    return 2 * c;
};
```
と書いていたのが
```
local f = |a, b| {
    local c = a + b;
    return 2 * c;
};
```
と書けるようになり、`|`を使っていてかつ関数式内部が1文なら
```
local f = |a, b| {
    2 * (a + b);
};
```
とreturnを省略出来るようにしてみました。

`|`を使っている関係上、引数無しの関数式を記述すると
```
local f = || {};
```
と論理和演算子`||`と被るため、関数式のパース処理にLogicalOrが出張しています。
どうにかしたかったですがどうにもなりませんでした。