### PR TITLE
Charsetヘッダに改行が無かったので追加

### DIFF
--- a/aosora-shiori/Misc/SaoriLoader.cpp
+++ b/aosora-shiori/Misc/SaoriLoader.cpp
@@ -259,6 +259,7 @@ namespace sakura {
 			assert(false);
 			break;
 		}
+		request.append("\r\n");
 
 		request.append("SecurityLevel: ");
 		switch (securityLevel) {


### PR DESCRIPTION
SAORIのrequest呼び出し時に
Charset: UTF-8SecutiryLevel: ...
のようになっていたので修正しました。