### PR TITLE
asunitの読み込み時にもゴーストのルートパスを先頭に追加するようにした。

### DIFF
--- a/aosora-shiori/Misc/ProjectParser.cpp
+++ b/aosora-shiori/Misc/ProjectParser.cpp
@@ -155,8 +155,10 @@ namespace sakura {
 		//列挙されたユニットファイルを
 		{
 			for (size_t i = 0; i < projectSettings.unitFiles.size(); i++) {
+				std::filesystem::path unitFilePath = gmp;
 				std::string target = projectSettings.unitFiles[i];
-				std::ifstream settingsStream(target);
+				unitFilePath.append(target);
+				std::ifstream settingsStream(unitFilePath);
 
 				if (settingsStream.fail()) {
 					//読み込みエラー


### PR DESCRIPTION
Windowsでは特に問題なく動くと思いますが、POSIXではゴーストのルートパス(`/path/to/ghost/master/`)を
付けてあげないと.asunitの読み込みに失敗するので修正しました。